### PR TITLE
Update Jenkins Agent's Entrypoint

### DIFF
--- a/resources/jenkins-agent/Dockerfile
+++ b/resources/jenkins-agent/Dockerfile
@@ -31,5 +31,5 @@ RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-ENTRYPOINT []
+ENTRYPOINT ["/bin/bash/", "-c"]
 CMD /usr/bin/supervisord --configuration /etc/supervisor/conf.d/supervisord.conf

--- a/resources/jenkins-agent/Dockerfile
+++ b/resources/jenkins-agent/Dockerfile
@@ -31,5 +31,5 @@ RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-ENTRYPOINT ["/bin/bash/", "-c"]
-CMD /usr/bin/supervisord --configuration /etc/supervisor/conf.d/supervisord.conf
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD ["/usr/bin/supervisord", "--configuration", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/resources/jenkins-agent/Dockerfile
+++ b/resources/jenkins-agent/Dockerfile
@@ -32,4 +32,4 @@ RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["/usr/bin/supervisord", "--configuration", "/etc/supervisor/conf.d/supervisord.conf"]
+CMD ["/usr/bin/supervisord --configuration /etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

I encountered an Openshift cluster that was interpreting `ENTRYPOINT []` as `ENTRYPOINT null`. That changed the startup command from `/bin/sh -c /usr/bin/supervisord --configuration /etc/supervisor/conf.d/supervisord.conf` to `/bin/sh -c null /bin/sh -c /usr/bin/supervisord --configuration /etc/supervisor/conf.d/supervisord.conf` and caused an error.

This pull request changes the ENTRYPOINT and CMD layers to accommodate this (curious) way of interpreting Dockerfiles.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Replicated the error being thrown by the Jenkins-Agent container in a given cluster
* Made the proposed changes
* changed the Git Reference in the OpenShift Build to "update-agent-entrypoint"
* Ran a new build
* Checked to see if the Jenkins-Agent container threw error (it didn't)
* Checked to see that the Agent connected to the Master (it did)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have updated the Change Log appropriately. 