### PR TITLE
Jenkins agent dockerfile update

### DIFF
--- a/resources/jenkins-agent/Dockerfile
+++ b/resources/jenkins-agent/Dockerfile
@@ -10,10 +10,10 @@ ENV JAVA_HOME /usr/lib/jvm/java
 
 RUN mkdir -p /opt/jenkins-slave/bin ${HOME}
 
-RUN apk add --no-cache curl openjdk8 git device-mapper openssl
+RUN apk add --no-cache curl openjdk8 git device-mapper openssl-dev build-base
 
 # install docker-compose
-RUN apk add --no-cache py-pip curl supervisor && \
+RUN apk add --no-cache py-pip curl supervisor libffi-dev python-dev && \
     pip install docker-compose
 
 # set PID max to 99999

--- a/resources/jenkins-agent/Dockerfile
+++ b/resources/jenkins-agent/Dockerfile
@@ -8,26 +8,22 @@ ENV JNLP_SLAVE_VERSION 3.9
 ENV HOME /root
 ENV JAVA_HOME /usr/lib/jvm/java
 
-RUN mkdir -p /opt/jenkins-slave/bin ${HOME}
-
-RUN apk add --no-cache curl openjdk8 git device-mapper openssl-dev build-base
-
-# install docker-compose
-RUN apk add --no-cache py-pip curl supervisor libffi-dev python-dev && \
-    pip install docker-compose
-
-# set PID max to 99999
-# bc of docker bug w/ 6 character pid
-RUN echo "kernel.pid_max=99999" >> /etc/sysctl.d/00-alpine.conf
+RUN mkdir -p /opt/jenkins-slave/bin ${HOME} && \
+    apk add --no-cache curl openjdk8 git device-mapper openssl-dev build-base nss && \
+    # install docker-compose
+    apk add --no-cache py-pip curl supervisor libffi-dev python-dev && \
+    pip install docker-compose && \
+    # set PID max to 99999
+    # bc of docker bug w/ 6 character pid
+    echo "kernel.pid_max=99999" >> /etc/sysctl.d/00-alpine.conf
 
 # Copy script
 COPY jenkins-agent.sh /opt/jenkins-slave/bin/jenkins-slave
-RUN chmod 777 /opt/jenkins-slave/bin/jenkins-slave
-RUN chmod +x /opt/jenkins-slave/bin/jenkins-slave
-
-# Download plugin and modify permissions
-RUN curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_VERSION.jar http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION.jar \
-  && curl --create-dirs -sSLo /opt/jenkins-slave/bin/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/$JNLP_SLAVE_VERSION/remoting-$JNLP_SLAVE_VERSION.jar
+RUN chmod 777 /opt/jenkins-slave/bin/jenkins-slave && \
+    chmod +x /opt/jenkins-slave/bin/jenkins-slave && \
+    # Download plugin and modify permissions
+    curl --create-dirs -sSLo /opt/jenkins-slave/bin/swarm-client-$JENKINS_SWARM_VERSION.jar http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION.jar && \ 
+    curl --create-dirs -sSLo /opt/jenkins-slave/bin/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/$JNLP_SLAVE_VERSION/remoting-$JNLP_SLAVE_VERSION.jar
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Adding to the Jenkins Agent image Alpine libraries that seem to have gone away, possibly when the base `docker:dind` image updated to Alpine 3.9 last month.

## Description

Added the following libraries to the image through apk:
* build-base (for gcc)
* openssl-dev (replacing openssl)
* libffi-dev
* python-dev

Consolidated some of the `RUN` layers to hopefully reduce the jenkins-agent image's overall size

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified that the image could be built using the --no-cache option (`docker build --no-cache resources/jenkins-agent`)
Verified that the image, when deployed in Openshift, successfully connected to the Jenkins master, and was able to successfully execute code in a sample pipeline ([pipeline-config](https://github.com/kottoson-bah/pipeline-configuration/tree/openshift-sq), [source code](https://github.com/kottoson-bah/sdp-example-proj))

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] I have updated the Change Log appropriately. 